### PR TITLE
update rakyll/portmidi dependency

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.14
 
 require (
 	github.com/godbus/dbus v4.1.0+incompatible
+	github.com/rakyll/portmidi v0.0.0-20201020180702-d436ceaa537a // indirect
 	github.com/rs/zerolog v1.19.0
 	github.com/spf13/viper v1.7.0
 	github.com/sqp/pulseaudio v0.0.0-20180916175200-29ac6bfa231c

--- a/go.sum
+++ b/go.sum
@@ -146,6 +146,8 @@ github.com/prometheus/procfs v0.0.0-20190507164030-5867b95ac084/go.mod h1:TjEm7z
 github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40TwIPHuXU=
 github.com/rakyll/portmidi v0.0.0-20170620004031-e434d7284291 h1:hl7rQwLldjB+FCyUuxSFCAx986GONIoRQwsMesdOknE=
 github.com/rakyll/portmidi v0.0.0-20170620004031-e434d7284291/go.mod h1:tO1ylmFo6+hnYFvj/fd92q30wkNQwgWC/8mcHq0KkQU=
+github.com/rakyll/portmidi v0.0.0-20201020180702-d436ceaa537a h1:+qeh9b4LlO8AYVvm+TG4OXDRwBynTLk82t0HDBBBOQ8=
+github.com/rakyll/portmidi v0.0.0-20201020180702-d436ceaa537a/go.mod h1:xKffaBd7e1YUoLpR2azvJqkxEdUDNGNDMlsUNdv6Bcs=
 github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af/go.mod h1:XWv6SoW27p1b0cqNHllgS5HIMJraePCO15w5zCzIWYg=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
 github.com/rs/xid v1.2.1/go.mod h1:+uKXf+4Djp6Md1KODXJxgGQPKngRmWyn10oCKFzNHOQ=

--- a/vendor/github.com/rakyll/portmidi/README.md
+++ b/vendor/github.com/rakyll/portmidi/README.md
@@ -84,18 +84,3 @@ Cleanup your input and output streams once you're done. Likely to be called on g
 ~~~ go
 portmidi.Terminate()
 ~~~
-    
-## License
-    Copyright 2013 Google Inc. All Rights Reserved.
-    
-    Licensed under the Apache License, Version 2.0 (the "License");
-    you may not use this file except in compliance with the License.
-    You may obtain a copy of the License at
-    
-         http://www.apache.org/licenses/LICENSE-2.0
-    
-    Unless required by applicable law or agreed to in writing, software
-    distributed under the License is distributed on an "AS IS" BASIS,
-    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-    See the License for the specific language governing permissions and
-    limitations under the License.

--- a/vendor/github.com/rakyll/portmidi/go.mod
+++ b/vendor/github.com/rakyll/portmidi/go.mod
@@ -1,0 +1,3 @@
+module github.com/rakyll/portmidi
+
+go 1.14

--- a/vendor/github.com/rakyll/portmidi/portmidi.go
+++ b/vendor/github.com/rakyll/portmidi/portmidi.go
@@ -17,7 +17,6 @@ package portmidi
 
 // #cgo CFLAGS:  -I/usr/local/include
 // #cgo LDFLAGS: -lportmidi -L/usr/local/lib
-// #cgo linux LDFLAGS: -lporttime
 //
 // #include <stdlib.h>
 // #include <portmidi.h>

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -20,7 +20,8 @@ github.com/magiconair/properties
 github.com/mitchellh/mapstructure
 # github.com/pelletier/go-toml v1.2.0
 github.com/pelletier/go-toml
-# github.com/rakyll/portmidi v0.0.0-20170620004031-e434d7284291
+# github.com/rakyll/portmidi v0.0.0-20201020180702-d436ceaa537a
+## explicit
 github.com/rakyll/portmidi
 # github.com/rs/zerolog v1.19.0
 ## explicit


### PR DESCRIPTION
Update [rakyll/portmidi](https://github.com/rakyll/portmidi) to latest. rakyll/portmidi is a dependency of [gomidi/portmididrv](https://gitlab.com/gomidi/portmididrv)

This resolves the issue mentioned in https://github.com/solarnz/pamidicontrol/issues/5: 
> cannot find -lporttime. 


Additionally, I noticed that the [2023-dep-update](https://github.com/solarnz/pamidicontrol/tree/2023-deps-update) updates/fixes the outdated dependency rakyll/portmidi, but it has neither been merged nor is able to see/read any controlChanges of my midi device. This pr should fix these issues.

Changes: 

- Update rakyll/portmidi to latest.
  -  resolves -lporttime.

